### PR TITLE
added linting part for "prefix your variables" documentation

### DIFF
--- a/docs/prefix_your_variables.md
+++ b/docs/prefix_your_variables.md
@@ -34,3 +34,11 @@ Now you want to create a variable that configures the default listen-port.
 Other than the reason mentioned earlier, there’s no ambiguity here. You definitely know that this variable belongs to the apache-role. There could be another role for some other kind of software that also defines a listen-port. With prefixed variables this is not a problem since variables have their own namespace now.
 
 By the way, Puppet and Chef are on the advantage here, having namespaces for their roles. Ansible is not designed this way.
+
+## Linting
+
+Since ansible-lint v6.16.1 a new linting rule has been added which says: "Variables names from within roles should use role_name_ as a prefix.".
+
+Possible rule set that could fail: var-naming[no-role-prefix]
+
+For more information see the official ansible-lint documentation: https://ansible-lint.readthedocs.io/rules/var-naming/#var-naming

--- a/docs/prefix_your_variables.md
+++ b/docs/prefix_your_variables.md
@@ -39,6 +39,6 @@ By the way, Puppet and Chef are on the advantage here, having namespaces for the
 
 Since ansible-lint v6.16.1 a new linting rule has been added which says: "Variables names from within roles should use role_name_ as a prefix.".
 
-Possible rule set that could fail: var-naming[no-role-prefix]
+Possible error message: var-naming[no-role-prefix]
 
 For more information see the official ansible-lint documentation: https://ansible-lint.readthedocs.io/rules/var-naming/#var-naming


### PR DESCRIPTION
Added documentation for the new linting rule: https://ansible-lint.readthedocs.io/rules/var-naming/ in our docs.